### PR TITLE
Fix mobile layout issues

### DIFF
--- a/src/components/certificationCard/CertificationCard.css
+++ b/src/components/certificationCard/CertificationCard.css
@@ -155,4 +155,11 @@
     width: 100%;
     font-size: 16px;
   }
+
+  .cert-card {
+    flex: 0 0 auto;
+    min-width: 80%;
+    scroll-snap-align: start;
+    margin-right: 1rem;
+  }
 }

--- a/src/components/degreeCard/DegreeCard.css
+++ b/src/components/degreeCard/DegreeCard.css
@@ -55,11 +55,13 @@
   font-family: "Google Sans Regular";
 }
 
+
 .education-item-footer {
   display: flex;
-  justify-content: space-between; /* This will keep a gap between the two buttons */
+  justify-content: center;
   align-items: center;
-  flex-wrap: wrap; /* If there isn't enough space for both buttons side by side, they will wrap */
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .education-item-footer a {
@@ -76,23 +78,25 @@
   }
 
   .body-header {
-    flex-direction: column;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 
   .body-header-title {
-    width: 100%;
+    width: 65%;
   }
 
   .body-header-duration {
     padding: 0;
     margin: 0;
-    width: 100%;
+    width: auto;
   }
 
   .duration {
-    padding: 0px;
-    margin: 0px;
-    float: left;
+    padding: 0;
+    margin: 0;
+    float: none;
   }
 
   .card-title {
@@ -104,18 +108,19 @@
   }
 
   .education-item-footer {
-    flex-direction: column; /* Stack the buttons vertically for small screens */
-    align-items: stretch;   /* Let the buttons take full width */
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
   }
 
   .education-item-footer a p {
-    margin-left: 0; /* Reset left margin */
-    margin-right: 0; /* Reset right margin */
+    margin-left: 0;
+    margin-right: 0;
     width: 100%;
   }
 
   .education-item-footer a {
-    margin: 8px 0;
+    margin: 0;
   }
 
   .education-btn {

--- a/src/containers/certifications/Certifications.css
+++ b/src/containers/certifications/Certifications.css
@@ -7,10 +7,10 @@
 
 .certifications-body-div {
   display: grid;
-  grid-template-columns: repeat(2, 1fr); /* Two columns by default */
+  grid-template-columns: repeat(2, 1fr);
   gap: 2rem;
   padding: 0 2rem;
-  justify-items: center; /* Center items horizontally in grid cells */
+  justify-items: center;
   max-width: 1000px;
   margin: 0 auto;
 }
@@ -22,10 +22,17 @@
   }
 }
 
-/* Small screens: switch to one column */
+/* Small screens: horizontal scroll to reduce vertical space */
 @media (max-width: 768px) {
   .certifications-body-div {
-    grid-template-columns: 1fr;
+    display: flex;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+  }
+
+  .certifications-body-div::-webkit-scrollbar {
+    display: none;
   }
 
   .certifications-header {

--- a/src/containers/skills/SkillSection.js
+++ b/src/containers/skills/SkillSection.js
@@ -33,7 +33,9 @@ function SkillSection(props) {
       <Tabs
         value={tabIndex}
         onChange={handleChange}
-        centered
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
         textColor="primary"
         indicatorColor="primary"
       >

--- a/src/containers/skills/Skills.css
+++ b/src/containers/skills/Skills.css
@@ -1,6 +1,8 @@
 
 .skills-tabs {
   margin-top: 50px;
+  overflow-x: auto;
+  white-space: nowrap;
 }
 
 .skills-main-div {


### PR DESCRIPTION
## Summary
- make the skills tabs scrollable on mobile
- tweak degree card layout for small screens
- reduce spacing between degree buttons

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: SyntaxError when Jest runs `@iconify/react`)*

------
https://chatgpt.com/codex/tasks/task_e_684483b37500833097f334f1d0534c01