### PR TITLE
Style skills tabs and improve list appearance

### DIFF
--- a/src/components/degreeCard/DegreeCard.css
+++ b/src/components/degreeCard/DegreeCard.css
@@ -50,9 +50,25 @@
 }
 
 .content-list {
-  padding-left: 10px;
-  padding-right: 10px;
+  list-style: none;
+  padding-left: 0;
+  padding-right: 0;
   font-family: "Google Sans Regular";
+  margin: 0;
+}
+
+.content-list li {
+  margin-bottom: 8px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.content-list li::before {
+  content: "▹";
+  position: absolute;
+  left: 0;
+  color: var(--accent-color);
+  font-weight: bold;
 }
 
 

--- a/src/components/degreeCard/DegreeCard.js
+++ b/src/components/degreeCard/DegreeCard.js
@@ -107,15 +107,11 @@ function DegreeCard(props) {
           </div>
 
           <div className="body-content">
-            {degree.descriptions.map((sentence, index) => (
-              <p
-                key={index}
-                className="content-list"
-                style={{ color: theme.text }}
-              >
-                {sentence}
-              </p>
-            ))}
+            <ul className="content-list" style={{ color: theme.text }}>
+              {degree.descriptions.map((sentence, index) => (
+                <li key={index}>{sentence}</li>
+              ))}
+            </ul>
 
             <div className="education-item-footer">
               {degree.transcript_link && (

--- a/src/components/experienceCard/ExperienceCard.css
+++ b/src/components/experienceCard/ExperienceCard.css
@@ -90,6 +90,26 @@
   line-height: 1.6;
 }
 
+.experience-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.experience-list li {
+  margin-bottom: 8px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.experience-list li::before {
+  content: "▹";
+  position: absolute;
+  left: 0;
+  color: var(--accent-color);
+  font-weight: bold;
+}
+
 .experience-card-company > a {
   position: relative;
   color: #8c8c8c;

--- a/src/components/experienceCard/ExperienceCard.js
+++ b/src/components/experienceCard/ExperienceCard.js
@@ -54,12 +54,12 @@ function ExperienceCard(props) {
           </div>
         </div>
         <div className="experience-card-description" style={{ color: theme.text }}>
-        {experience.description.map((desc, index) => (
-          <p key={index} className="experience-card-description" style={{ color: theme.text }}>
-            {desc}
-          </p>
-        ))}
-      </div>
+          <ul className="experience-list">
+            {experience.description.map((desc, index) => (
+              <li key={index}>{desc}</li>
+            ))}
+          </ul>
+        </div>
       
 
       </div>

--- a/src/containers/skills/SkillSection.js
+++ b/src/containers/skills/SkillSection.js
@@ -6,6 +6,9 @@ import Fade from "@mui/material/Fade";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Box from "@mui/material/Box";
+import CodeIcon from "@mui/icons-material/Code";
+import CloudIcon from "@mui/icons-material/Cloud";
+import ScienceIcon from "@mui/icons-material/Science";
 
 function TabPanel({ children, value, index }) {
   return (
@@ -28,8 +31,10 @@ function SkillSection(props) {
     setTabIndex(newValue);
   };
 
+  const tabIcons = [<CodeIcon />, <CloudIcon />, <ScienceIcon />];
+
   return (
-    <div className="skills-tabs">
+    <Box className="skills-tabs">
       <Tabs
         value={tabIndex}
         onChange={handleChange}
@@ -43,6 +48,8 @@ function SkillSection(props) {
           <Tab
             key={index}
             label={skill.title}
+            icon={tabIcons[index]}
+            iconPosition="start"
             sx={{ color: theme.text }}
           />
         ))}
@@ -67,7 +74,7 @@ function SkillSection(props) {
           </div>
         </TabPanel>
       ))}
-    </div>
+    </Box>
   );
 }
 

--- a/src/containers/skills/Skills.css
+++ b/src/containers/skills/Skills.css
@@ -3,6 +3,8 @@
   margin-top: 50px;
   overflow-x: auto;
   white-space: nowrap;
+  display: flex;
+  justify-content: center;
 }
 
 .skills-main-div {
@@ -28,9 +30,23 @@
 }
 
 .skills-list {
-  list-style-type: disc;
-  padding-left: 20px;
+  list-style: none;
+  padding-left: 0;
   margin: 0;
+}
+
+.skills-list li {
+  margin-bottom: 8px;
+  padding-left: 20px;
+  position: relative;
+}
+
+.skills-list li::before {
+  content: "▹";
+  position: absolute;
+  left: 0;
+  color: var(--accent-color);
+  font-weight: bold;
 }
 
 .skills-tab-panel {


### PR DESCRIPTION
## Summary
- center the skills tab bar and add icons for each tab
- prettify bullet lists across skills, experience and education sections

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6844dc99149c83309f33214ca0aac949